### PR TITLE
Serde support through a feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ parking_lot = {version = "0.12.2", optional = true}
 tokio = {version = "1.37.0", default-features = false, features = ["rt", "sync", "time"]}
 textwrap = {version = "0.16.1", optional = true}
 unicode-width = "0.1.12"
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = {version = "0.2.144"}
@@ -29,13 +30,15 @@ libc = {version = "0.2.144"}
 default = ["wrap", "history", "completion", "global"]
 # Best-effort attempt to capture stderr and route it through liso. Not a
 # supported feature. Experimental.
-capture-stderr = ["libc", "errno", "parking_lot"]
+capture-stderr = ["dep:libc", "dep:errno", "dep:parking_lot"]
 # Tab-completion support.
 completion = []
 # Global `output()` function and `println!`/`wrapln!` macros. No plumbing
 # required.
-global = ["parking_lot"]
+global = ["dep:parking_lot"]
 # History support.
 history = []
 # `wrapln()` function.
-wrap = ["textwrap"]
+wrap = ["dep:textwrap"]
+# derive Serialize and Deserialize for Line, LineElement, Color, and Style
+serde = ["dep:serde", "bitflags/serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,7 @@ impl From<std_mpsc::RecvTimeoutError> for DummyError {
 /// - Instead of setting white-on-black or black-on-white, consider using
 ///   [inverse video](struct.Style.html#associatedconstant.INVERSE) to achieve
 ///   your goal instead.
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Color {
@@ -314,6 +315,7 @@ bitflags! {
     /// it. On any standards-compliant terminal, unsupported features will be
     /// ignored. Even on standards-compliant terminals, these are very open to
     /// interpretation.
+    #[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
     pub struct Style: u32 {
         /// No styling at all. (A nice alias for `Style::empty()`.)
@@ -398,6 +400,7 @@ pub struct InputOutput {
 const MAX_DEATH_COUNT: u32 = 9;
 
 /// An individual styled span within a line.
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LineElement {
     /// The style in effect.
@@ -416,6 +419,7 @@ struct LineElement {
 /// display. The [`liso!`](macro.liso.html) macro is extremely convenient for
 /// building these. You can also pass a `String`, `&str`, or `Cow<str>` to
 /// most Liso functions that accept a `Line`.
+#[cfg_attr(feature="serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Line {
     text: String,


### PR DESCRIPTION
Been using this crate in very simple commandline chat server/client, so to send stylized messages I needed to serialize `liso::Line`.

Turned out to be dead simple, just derive everything through serde.

On another note: prehaps consider using the `ansi_term` crate for style and colour? It looks to me to be much more standardized, and comes with serde support out of the box. (just a thought, haven't used it myself yet)